### PR TITLE
Initial state

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "epoch"
-version = "1.0.0-alpha.14"
+version = "1.0.0-alpha.15"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ esdb = ["dep:eventstore", "dep:uuid_0_8_2", "dep:serde_json"]
 
 [dependencies]
 async-trait = "0.1.53"
-eventstore = { version = "2.1.1",  optional = true }
+eventstore = { version = "2.1, < 2.2",  optional = true }
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = { version = "1.0.81", optional = true }
 thiserror = "1.0"

--- a/src/decider.rs
+++ b/src/decider.rs
@@ -69,7 +69,7 @@ mod tests {
         let events = <UserDecider as Decider>::decide(&state, &cmd).expect("Decider Success");
 
         if let Some(UserEvent::UserAdded(user::User { name, id, .. })) = events.clone().first() {
-            let user_id = id.clone();
+            let user_id = *id;
             let user_name = name.clone();
 
             assert_eq!(name.value(), "Mike".to_string());
@@ -79,7 +79,7 @@ mod tests {
             let _ = state_repository.save(&state).await;
             assert_eq!(state_repository.reify().await, state.clone());
 
-            assert_matches!(state.users.get(&id).expect("User exists"), user::User {
+            assert_matches!(state.users.get(&user_id).expect("User exists"), user::User {
                 id,
                 name,
                 ..

--- a/src/decider.rs
+++ b/src/decider.rs
@@ -30,7 +30,6 @@ pub trait Evolver {
     type State: Debug;
     type Evt: Event + Debug;
     fn evolve(state: Self::State, event: &Self::Evt) -> Self::State;
-    fn init(&self) -> Self::State;
 }
 
 #[cfg(test)]
@@ -63,7 +62,7 @@ mod tests {
             .await
             .expect("Empty Events Vector")
             .iter()
-            .fold(UserDecider.init(), UserDecider::evolve);
+            .fold(UserDeciderState::default(), UserDecider::evolve);
 
         let cmd = UserCommand::AddUser("Mike".to_string() as user::UnvalidatedUserName);
         let events = <UserDecider as Decider>::decide(&state, &cmd).expect("Decider Success");

--- a/src/decider.rs
+++ b/src/decider.rs
@@ -30,7 +30,7 @@ pub trait Evolver {
     type State: Debug;
     type Evt: Event + Debug;
     fn evolve(state: Self::State, event: &Self::Evt) -> Self::State;
-    fn init() -> Self::State;
+    fn init(&self) -> Self::State;
 }
 
 #[cfg(test)]
@@ -63,7 +63,7 @@ mod tests {
             .await
             .expect("Empty Events Vector")
             .iter()
-            .fold(UserDecider::init(), UserDecider::evolve);
+            .fold(UserDecider.init(), UserDecider::evolve);
 
         let cmd = UserCommand::AddUser("Mike".to_string() as user::UnvalidatedUserName);
         let events = <UserDecider as Decider>::decide(&state, &cmd).expect("Decider Success");

--- a/src/repository/esdb/mod.rs
+++ b/src/repository/esdb/mod.rs
@@ -240,6 +240,7 @@ mod tests {
         let cmd = UserCommand::AddGuitar(user_id, guitar.to_owned());
 
         let res = UserDecider::execute(
+            &UserDecider,
             &mut event_repository,
             &StreamState::Existing(user_id.to_string()),
             &ctx,
@@ -274,10 +275,16 @@ mod tests {
 
         let cmd1 = UserCommand::AddUser("Mike".to_string());
 
-        let evts =
-            UserDecider::execute(&mut event_repository, &StreamState::New, &ctx, &cmd1, None)
-                .await
-                .expect("command_succeeds");
+        let evts = UserDecider::execute(
+            &UserDecider,
+            &mut event_repository,
+            &StreamState::New,
+            &ctx,
+            &cmd1,
+            None,
+        )
+        .await
+        .expect("command_succeeds");
 
         let first_id = evts.first().unwrap().get_id();
 
@@ -286,9 +293,10 @@ mod tests {
             UserEvent::UserAdded(User { id, name, .. }) if (&first_id == id) && (name.value() == "Mike".to_string())
         );
 
-        let state = UserDeciderState::load_by_id(&event_repository, &first_id.to_string())
-            .await
-            .expect("state is loaded");
+        let state =
+            UserDeciderState::load_by_id(&UserDecider, &event_repository, &first_id.to_string())
+                .await
+                .expect("state is loaded");
 
         assert_matches!(
             state,
@@ -335,9 +343,10 @@ mod tests {
 
         thread::sleep(time::Duration::from_secs(1));
 
-        let state = UserDeciderState::load_by_id(&event_repository, &first_id.to_string())
-            .await
-            .expect("state is loaded");
+        let state =
+            UserDeciderState::load_by_id(&UserDecider, &event_repository, &first_id.to_string())
+                .await
+                .expect("state is loaded");
 
         assert_eq!(
             state.users.get(&first_id).unwrap().guitars,

--- a/src/repository/esdb/mod.rs
+++ b/src/repository/esdb/mod.rs
@@ -240,7 +240,7 @@ mod tests {
         let cmd = UserCommand::AddGuitar(user_id, guitar.to_owned());
 
         let res = UserDecider::execute(
-            &UserDecider,
+            UserDeciderState::default(),
             &mut event_repository,
             &StreamState::Existing(user_id.to_string()),
             &ctx,
@@ -276,7 +276,7 @@ mod tests {
         let cmd1 = UserCommand::AddUser("Mike".to_string());
 
         let evts = UserDecider::execute(
-            &UserDecider,
+            UserDeciderState::default(),
             &mut event_repository,
             &StreamState::New,
             &ctx,
@@ -293,10 +293,13 @@ mod tests {
             UserEvent::UserAdded(User { id, name, .. }) if (&first_id == id) && (name.value() == "Mike".to_string())
         );
 
-        let state =
-            UserDeciderState::load_by_id(&UserDecider, &event_repository, &first_id.to_string())
-                .await
-                .expect("state is loaded");
+        let state = UserDeciderState::load_by_id(
+            UserDeciderState::default(),
+            &event_repository,
+            &first_id.to_string(),
+        )
+        .await
+        .expect("state is loaded");
 
         assert_matches!(
             state,
@@ -343,10 +346,13 @@ mod tests {
 
         thread::sleep(time::Duration::from_secs(1));
 
-        let state =
-            UserDeciderState::load_by_id(&UserDecider, &event_repository, &first_id.to_string())
-                .await
-                .expect("state is loaded");
+        let state = UserDeciderState::load_by_id(
+            UserDeciderState::default(),
+            &event_repository,
+            &first_id.to_string(),
+        )
+        .await
+        .expect("state is loaded");
 
         assert_eq!(
             state.users.get(&first_id).unwrap().guitars,

--- a/src/strategies/mod.rs
+++ b/src/strategies/mod.rs
@@ -19,7 +19,7 @@ where
     type Ev: Evolver + Send + Sync;
 
     async fn load<'a, Err>(
-        evolver: &Self::Ev,
+        initial: <Self::Ev as Evolver>::State,
         event_repository: &(impl VersionedEventRepositoryWithStreams<'a, <Self::Ev as Evolver>::Evt, Err>
               + Send
               + Sync),
@@ -32,11 +32,11 @@ where
             .await?
             .0
             .iter()
-            .fold(evolver.init(), Self::Ev::evolve))
+            .fold(initial, Self::Ev::evolve))
     }
 
     async fn load_by_id<'a, Err, StreamId>(
-        evolver: &Self::Ev,
+        initial: <Self::Ev as Evolver>::State,
         event_repository: &(impl VersionedEventRepositoryWithStreams<
             'a,
             <Self::Ev as Evolver>::Evt,
@@ -55,7 +55,7 @@ where
             .await?
             .0
             .iter()
-            .fold(evolver.init(), Self::Ev::evolve))
+            .fold(initial, Self::Ev::evolve))
     }
 }
 
@@ -80,7 +80,7 @@ where
     }
 
     async fn execute<'a, RepoErr, StreamId>(
-        decider: &Self::Decide,
+        initial: <Self::Decide as Evolver>::State,
         event_repository: &mut (impl VersionedEventRepositoryWithStreams<
             'a,
             <Self::Decide as Evolver>::Evt,
@@ -111,7 +111,7 @@ where
                 .map_err(Self::to_lda_error)?,
         };
 
-        let mut state = decider.init();
+        let mut state = initial;
 
         for r in 1..retrys.unwrap_or(20) {
             state = decider_evts
@@ -300,7 +300,7 @@ mod tests {
         let cmd1 = UserCommand::AddUser("Mike".to_string());
 
         let evts = UserDecider::execute(
-            &UserDecider,
+            UserDeciderState::default(),
             &mut event_repository,
             &StreamState::New,
             &ctx,
@@ -317,10 +317,13 @@ mod tests {
             UserEvent::UserAdded(User { id, name, .. }) if (&first_id == id) && (name.value() == "Mike".to_string())
         );
 
-        let state =
-            UserDeciderState::load_by_id(&UserDecider, &event_repository, &first_id.to_string())
-                .await
-                .expect("state is loaded");
+        let state = UserDeciderState::load_by_id(
+            UserDeciderState::default(),
+            &event_repository,
+            &first_id.to_string(),
+        )
+        .await
+        .expect("state is loaded");
 
         assert_matches!(
             state,
@@ -329,7 +332,7 @@ mod tests {
 
         let cmd2 = UserCommand::AddUser("Dmitiry".to_string());
         let evts = UserDecider::execute(
-            &UserDecider,
+            UserDeciderState::default(),
             &mut event_repository,
             &StreamState::New,
             &ctx,
@@ -346,10 +349,13 @@ mod tests {
             UserEvent::UserAdded(User { id, name, .. }) if (&second_id == id) && (name.value() == "Dmitiry".to_string())
         );
 
-        let state =
-            UserDeciderState::load_by_id(&UserDecider, &event_repository, &second_id.to_string())
-                .await
-                .expect("state is loaded");
+        let state = UserDeciderState::load_by_id(
+            UserDeciderState::default(),
+            &event_repository,
+            &second_id.to_string(),
+        )
+        .await
+        .expect("state is loaded");
 
         assert_matches!(
             state,
@@ -358,7 +364,7 @@ mod tests {
 
         let cmd3 = UserCommand::UpdateUserName(second_id.clone(), "Dmitiry2".to_string());
         let evts = UserDecider::execute(
-            &UserDecider,
+            UserDeciderState::default(),
             &mut event_repository,
             &StreamState::Existing(second_id.to_string()),
             &ctx,
@@ -373,10 +379,13 @@ mod tests {
             UserEvent::UserNameUpdated(id, name) if (id == &second_id) && (name == &UserName::try_from("Dmitiry2".to_string()).unwrap())
         );
 
-        let state =
-            UserDeciderState::load_by_id(&UserDecider, &event_repository, &second_id.to_string())
-                .await
-                .expect("state is loaded");
+        let state = UserDeciderState::load_by_id(
+            UserDeciderState::default(),
+            &event_repository,
+            &second_id.to_string(),
+        )
+        .await
+        .expect("state is loaded");
 
         assert_matches!(
             state,
@@ -387,7 +396,7 @@ mod tests {
             UserCommand::UpdateUserName(second_id.clone(), "DmitiryWayToLongToSucceed".to_string());
 
         let res = UserDecider::execute(
-            &UserDecider,
+            UserDeciderState::default(),
             &mut event_repository,
             &StreamState::Existing(second_id.to_string()),
             &ctx,
@@ -401,17 +410,20 @@ mod tests {
             Err(LoadDecideAppendError::DecideErr(UserDeciderError::UserField(UserFieldError::NameToLong(n)))) if n == "DmitiryWayToLongToSucceed".to_string()
         );
 
-        let state =
-            UserDeciderState::load_by_id(&UserDecider, &event_repository, &second_id.to_string())
-                .await
-                .expect("state is loaded");
+        let state = UserDeciderState::load_by_id(
+            UserDeciderState::default(),
+            &event_repository,
+            &second_id.to_string(),
+        )
+        .await
+        .expect("state is loaded");
 
         assert_matches!(
             state,
             UserDeciderState { users } if users == HashMap::from([(second_id.clone(),  User::new(second_id, UserName::try_from("Dmitiry2".to_string()).unwrap()))])
         );
 
-        let state = UserDeciderState::load(&UserDecider, &event_repository)
+        let state = UserDeciderState::load(UserDeciderState::default(), &event_repository)
             .await
             .expect("state is loaded");
 

--- a/src/strategies/mod.rs
+++ b/src/strategies/mod.rs
@@ -19,6 +19,7 @@ where
     type Ev: Evolver + Send + Sync;
 
     async fn load<'a, Err>(
+        evolver: &Self::Ev,
         event_repository: &(impl VersionedEventRepositoryWithStreams<'a, <Self::Ev as Evolver>::Evt, Err>
               + Send
               + Sync),
@@ -31,10 +32,11 @@ where
             .await?
             .0
             .iter()
-            .fold(<Self::Ev as Evolver>::init(), Self::Ev::evolve))
+            .fold(evolver.init(), Self::Ev::evolve))
     }
 
     async fn load_by_id<'a, Err, StreamId>(
+        evolver: &Self::Ev,
         event_repository: &(impl VersionedEventRepositoryWithStreams<
             'a,
             <Self::Ev as Evolver>::Evt,
@@ -53,7 +55,7 @@ where
             .await?
             .0
             .iter()
-            .fold(<Self::Ev as Evolver>::init(), Self::Ev::evolve))
+            .fold(evolver.init(), Self::Ev::evolve))
     }
 }
 
@@ -78,6 +80,7 @@ where
     }
 
     async fn execute<'a, RepoErr, StreamId>(
+        decider: &Self::Decide,
         event_repository: &mut (impl VersionedEventRepositoryWithStreams<
             'a,
             <Self::Decide as Evolver>::Evt,
@@ -108,7 +111,7 @@ where
                 .map_err(Self::to_lda_error)?,
         };
 
-        let mut state = <Self::Decide as Evolver>::init();
+        let mut state = decider.init();
 
         for r in 1..retrys.unwrap_or(20) {
             state = decider_evts
@@ -273,7 +276,10 @@ mod tests {
 
     use crate::{
         decider::Event,
-        repository::in_memory::{versioned_with_streams::InMemoryEventRepository, state::versioned::InMemoryStateRepository},
+        repository::in_memory::{
+            state::versioned::InMemoryStateRepository,
+            versioned_with_streams::InMemoryEventRepository,
+        },
         test_helpers::{
             deciders::user::{
                 User, UserCommand, UserDecider, UserDeciderCtx, UserDeciderError, UserDeciderState,
@@ -293,10 +299,16 @@ mod tests {
 
         let cmd1 = UserCommand::AddUser("Mike".to_string());
 
-        let evts =
-            UserDecider::execute(&mut event_repository, &StreamState::New, &ctx, &cmd1, None)
-                .await
-                .expect("command_succeeds");
+        let evts = UserDecider::execute(
+            &UserDecider,
+            &mut event_repository,
+            &StreamState::New,
+            &ctx,
+            &cmd1,
+            None,
+        )
+        .await
+        .expect("command_succeeds");
 
         let first_id = evts.first().unwrap().get_id();
 
@@ -305,9 +317,10 @@ mod tests {
             UserEvent::UserAdded(User { id, name, .. }) if (&first_id == id) && (name.value() == "Mike".to_string())
         );
 
-        let state = UserDeciderState::load_by_id(&event_repository, &first_id.to_string())
-            .await
-            .expect("state is loaded");
+        let state =
+            UserDeciderState::load_by_id(&UserDecider, &event_repository, &first_id.to_string())
+                .await
+                .expect("state is loaded");
 
         assert_matches!(
             state,
@@ -315,10 +328,16 @@ mod tests {
         );
 
         let cmd2 = UserCommand::AddUser("Dmitiry".to_string());
-        let evts =
-            UserDecider::execute(&mut event_repository, &StreamState::New, &ctx, &cmd2, None)
-                .await
-                .expect("command_succeeds");
+        let evts = UserDecider::execute(
+            &UserDecider,
+            &mut event_repository,
+            &StreamState::New,
+            &ctx,
+            &cmd2,
+            None,
+        )
+        .await
+        .expect("command_succeeds");
 
         let second_id = evts.first().unwrap().get_id();
 
@@ -327,9 +346,10 @@ mod tests {
             UserEvent::UserAdded(User { id, name, .. }) if (&second_id == id) && (name.value() == "Dmitiry".to_string())
         );
 
-        let state = UserDeciderState::load_by_id(&event_repository, &second_id.to_string())
-            .await
-            .expect("state is loaded");
+        let state =
+            UserDeciderState::load_by_id(&UserDecider, &event_repository, &second_id.to_string())
+                .await
+                .expect("state is loaded");
 
         assert_matches!(
             state,
@@ -338,6 +358,7 @@ mod tests {
 
         let cmd3 = UserCommand::UpdateUserName(second_id.clone(), "Dmitiry2".to_string());
         let evts = UserDecider::execute(
+            &UserDecider,
             &mut event_repository,
             &StreamState::Existing(second_id.to_string()),
             &ctx,
@@ -352,9 +373,10 @@ mod tests {
             UserEvent::UserNameUpdated(id, name) if (id == &second_id) && (name == &UserName::try_from("Dmitiry2".to_string()).unwrap())
         );
 
-        let state = UserDeciderState::load_by_id(&event_repository, &second_id.to_string())
-            .await
-            .expect("state is loaded");
+        let state =
+            UserDeciderState::load_by_id(&UserDecider, &event_repository, &second_id.to_string())
+                .await
+                .expect("state is loaded");
 
         assert_matches!(
             state,
@@ -365,6 +387,7 @@ mod tests {
             UserCommand::UpdateUserName(second_id.clone(), "DmitiryWayToLongToSucceed".to_string());
 
         let res = UserDecider::execute(
+            &UserDecider,
             &mut event_repository,
             &StreamState::Existing(second_id.to_string()),
             &ctx,
@@ -378,16 +401,17 @@ mod tests {
             Err(LoadDecideAppendError::DecideErr(UserDeciderError::UserField(UserFieldError::NameToLong(n)))) if n == "DmitiryWayToLongToSucceed".to_string()
         );
 
-        let state = UserDeciderState::load_by_id(&event_repository, &second_id.to_string())
-            .await
-            .expect("state is loaded");
+        let state =
+            UserDeciderState::load_by_id(&UserDecider, &event_repository, &second_id.to_string())
+                .await
+                .expect("state is loaded");
 
         assert_matches!(
             state,
             UserDeciderState { users } if users == HashMap::from([(second_id.clone(),  User::new(second_id, UserName::try_from("Dmitiry2".to_string()).unwrap()))])
         );
 
-        let state = UserDeciderState::load(&event_repository)
+        let state = UserDeciderState::load(&UserDecider, &event_repository)
             .await
             .expect("state is loaded");
 
@@ -415,15 +439,15 @@ mod tests {
     async fn reify_decide_save_basic_functionality() {
         let ctx = UserDeciderCtx::new();
 
-        let mut state_repository = InMemoryStateRepository::<UserDeciderState>::new(UserDeciderState::default());
+        let mut state_repository =
+            InMemoryStateRepository::<UserDeciderState>::new(UserDeciderState::default());
 
         let cmd1 = UserCommand::AddUser("Mike".to_string());
 
-        let res = UserDecider::execute_reify_decide(&mut state_repository, &ctx, &cmd1, None).await.unwrap();
+        let res = UserDecider::execute_reify_decide(&mut state_repository, &ctx, &cmd1, None)
+            .await
+            .unwrap();
 
-        assert_eq!(
-            res.users.len(),
-            1
-        );
+        assert_eq!(res.users.len(), 1);
     }
 }

--- a/src/test_helpers/deciders.rs
+++ b/src/test_helpers/deciders.rs
@@ -11,7 +11,10 @@ pub(crate) mod user {
     use crate::{
         decider::{Decider, DeciderWithContext, Event, Evolver},
         repository::event::StreamIdFromEvent,
-        strategies::{DecideEvolveWithCommandResponse, LoadDecideAppend, StateFromEventRepository, ReifyDecideSave},
+        strategies::{
+            DecideEvolveWithCommandResponse, LoadDecideAppend, ReifyDecideSave,
+            StateFromEventRepository,
+        },
         test_helpers::ValueType,
     };
 
@@ -178,7 +181,7 @@ pub(crate) mod user {
             }
         }
 
-        fn init() -> UserDeciderState {
+        fn init(&self) -> UserDeciderState {
             UserDeciderState {
                 users: Default::default(),
             }

--- a/src/test_helpers/deciders.rs
+++ b/src/test_helpers/deciders.rs
@@ -180,12 +180,6 @@ pub(crate) mod user {
                 }
             }
         }
-
-        fn init(&self) -> UserDeciderState {
-            UserDeciderState {
-                users: Default::default(),
-            }
-        }
     }
 
     impl DeciderWithContext for UserDecider {


### PR DESCRIPTION
PR to discuss design implications of giving `Evolver.init()` access to &self per `Evolver.init(&self)`.