### PR TITLE
Evolver init with builder as alternative initial state

### DIFF
--- a/src/decider.rs
+++ b/src/decider.rs
@@ -33,7 +33,7 @@ pub trait DeciderWithContext: Evolver + Debug {
 }
 
 pub trait Evolver {
-    type State: InitializeableState;
+    type State: InitializeableState + Debug;
     type Evt: Event + Debug;
     fn evolve(state: Self::State, event: &Self::Evt) -> Self::State;
     fn init(creator: <Self::State as InitializeableState>::Creator) -> Self::State {

--- a/src/repository/esdb/mod.rs
+++ b/src/repository/esdb/mod.rs
@@ -240,6 +240,7 @@ mod tests {
         let cmd = UserCommand::AddGuitar(user_id, guitar.to_owned());
 
         let res = UserDecider::execute(
+            (),
             &mut event_repository,
             &StreamState::Existing(user_id.to_string()),
             &ctx,
@@ -274,10 +275,16 @@ mod tests {
 
         let cmd1 = UserCommand::AddUser("Mike".to_string());
 
-        let evts =
-            UserDecider::execute(&mut event_repository, &StreamState::New, &ctx, &cmd1, None)
-                .await
-                .expect("command_succeeds");
+        let evts = UserDecider::execute(
+            (),
+            &mut event_repository,
+            &StreamState::New,
+            &ctx,
+            &cmd1,
+            None,
+        )
+        .await
+        .expect("command_succeeds");
 
         let first_id = evts.first().unwrap().get_id();
 
@@ -286,7 +293,7 @@ mod tests {
             UserEvent::UserAdded(User { id, name, .. }) if (&first_id == id) && (name.value() == "Mike".to_string())
         );
 
-        let state = UserDeciderState::load_by_id(&event_repository, &first_id.to_string())
+        let state = UserDeciderState::load_by_id((), &event_repository, &first_id.to_string())
             .await
             .expect("state is loaded");
 
@@ -335,7 +342,7 @@ mod tests {
 
         thread::sleep(time::Duration::from_secs(1));
 
-        let state = UserDeciderState::load_by_id(&event_repository, &first_id.to_string())
+        let state = UserDeciderState::load_by_id((), &event_repository, &first_id.to_string())
             .await
             .expect("state is loaded");
 

--- a/src/repository/in_memory/state/versioned.rs
+++ b/src/repository/in_memory/state/versioned.rs
@@ -36,7 +36,9 @@ where
             RepositoryVersion::Exact(exact) => Ok(exact.to_owned()),
             RepositoryVersion::NoStream => Ok(0),
             RepositoryVersion::StreamExists => Ok(0),
-            RepositoryVersion::Any => Err(VersionedRepositoryError::RepoErr(Error::ExactStreamVersionMustBeKnown))
+            RepositoryVersion::Any => Err(VersionedRepositoryError::RepoErr(
+                Error::ExactStreamVersionMustBeKnown,
+            )),
         }
     }
 
@@ -55,9 +57,11 @@ where
     }
 
     fn bump_version(
-        version: &RepositoryVersion
+        version: &RepositoryVersion,
     ) -> Result<RepositoryVersion, VersionedRepositoryError<Error>> {
-        Ok(RepositoryVersion::Exact(Self::version_to_usize(version)? + 1))
+        Ok(RepositoryVersion::Exact(
+            Self::version_to_usize(version)? + 1,
+        ))
     }
 }
 

--- a/src/test_helpers/deciders.rs
+++ b/src/test_helpers/deciders.rs
@@ -9,9 +9,12 @@ pub(crate) mod user {
     use thiserror::Error;
 
     use crate::{
-        decider::{Decider, DeciderWithContext, Event, Evolver},
+        decider::{Decider, DeciderWithContext, Event, Evolver, InitializeableState},
         repository::event::StreamIdFromEvent,
-        strategies::{DecideEvolveWithCommandResponse, LoadDecideAppend, StateFromEventRepository, ReifyDecideSave},
+        strategies::{
+            DecideEvolveWithCommandResponse, LoadDecideAppend, ReifyDecideSave,
+            StateFromEventRepository,
+        },
         test_helpers::ValueType,
     };
 
@@ -178,7 +181,7 @@ pub(crate) mod user {
             }
         }
 
-        fn init() -> UserDeciderState {
+        fn init(_: ()) -> UserDeciderState {
             UserDeciderState {
                 users: Default::default(),
             }
@@ -259,6 +262,14 @@ pub(crate) mod user {
 
         pub fn set_users(&self, users: HashMap<UserId, User>) -> Self {
             Self { users, ..*self }
+        }
+    }
+
+    impl InitializeableState for UserDeciderState {
+        type Creator = ();
+
+        fn create(_: Self::Creator) -> Self {
+            Self::default()
         }
     }
 


### PR DESCRIPTION
Make "creator" parameterized in a generic way in case it needs some initialization or config to create initial state vs impl Default

This still ends up polluting strategies with extra arguments (solvable buy a builder struct as a single argument with sensible defaults) but avoided forcing struct members on a decider implementation or passing in a decider that already is already referenced statically in trait.